### PR TITLE
build: update to python3.9

### DIFF
--- a/graphite/docker-tag.sh
+++ b/graphite/docker-tag.sh
@@ -37,11 +37,15 @@ else
   ISO_TIMESTAMP=$(date -u --rfc-3339=seconds "-d@${UNIX_TIMESTAMP}" | sed "s/+.*$//g" | sed "s/[^0-9]*//g")
 fi
 
-# Generate docker tag
-DOCKER_TAG=$(echo "${ISO_TIMESTAMP}-master-${GIT_COMMIT_SHORT}" | tr "/" "_")
-
 # Jump back out
 popd
+
+# Get current repo commit SHA
+GRAPHITE_MT_SHA=$(git rev-parse HEAD | tr -d '\n')
+GRAPHITE_MT_SHORT="$(git rev-parse --short "$GRAPHITE_MT_SHA")"
+
+# Generate docker tag with both SHAs
+DOCKER_TAG=$(echo "${ISO_TIMESTAMP}-${GIT_COMMIT_SHORT}-${GRAPHITE_MT_SHORT}" | tr "/" "_")
 
 # Generate output files
 echo $COMMIT_SHA > .commit_sha


### PR DESCRIPTION
Updating to Python 3.9 automatically upgrades two vulnerable dependencies to versions in which they were fixed.
Note that 3.9 is stated as supported by Graphite Web: https://github.com/graphite-project/graphite-web/blob/c92e8c0a15cba3092c512c6fa991f955f9c23cce/CHANGELOG.md?plain=1#L124

Two piggybacking changes: 
1. Delete the snakeoil certs, which we don't need and were being marked as insecure
2. Update the docker-tag to include this repo's commit apart from graphite-web's