### PR TITLE
fix Python 3.9 compatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal AS build
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-RUN apt-get update && apt-get -y install build-essential libffi-dev libcairo2-dev git wget python3.9 python3.9-dev python3-pip apache2 curl
+RUN apt-get update && apt-get -y install build-essential libffi-dev libcairo2-dev git wget python3.9 python3.9-dev python3-pip apache2 apache2-dev curl
 
 RUN python3.9 -m pip install --upgrade pip
 
@@ -17,6 +17,7 @@ RUN python3.9 -m virtualenv /opt/graphite \
   && /opt/graphite/bin/pip install https://github.com/graphite-project//graphite-web/tarball/$(cat .commit_sha) \
   && /opt/graphite/bin/pip install pycairo \
   && /opt/graphite/bin/pip install https://github.com/grafana/django-statsd/tarball/master \
+  && /opt/graphite/bin/pip install mod_wsgi \
   && cp -r /opt/graphite/lib/python3.9/site-packages/opt/graphite/webapp/* /opt/graphite/webapp/ \
   && cp /opt/graphite/conf/graphite.wsgi.example /opt/graphite/conf/graphite.wsgi \
   && find /opt/graphite/webapp ! -perm -a+r -exec chmod a+r {} \; \
@@ -29,7 +30,7 @@ ENV TZ=UTC
 
 RUN apt-get update && \
     apt-get install -y --only-upgrade libc-bin libc6 && \
-    apt-get -y install python3.9 apache2 libapache2-mod-wsgi-py3 curl libcairo2 libffi7 && \
+    apt-get -y install python3.9 apache2 curl libcairo2 libffi7 libpython3.9 && \
     rm -rf /var/lib/apt/lists/* && \
     # we don't need the snakeoil certs in our setup, and they are flagged as insecure
     rm -rf /etc/ssl/private/ssl-cert-snakeoil.* 
@@ -40,7 +41,9 @@ COPY local_settings.py /opt/graphite/webapp/graphite/local_settings.py
 
 # configure apache
 COPY vhost.conf /etc/apache2/sites-available/graphite.conf
-RUN a2dissite 000-default && a2ensite graphite && a2enmod wsgi && a2enmod headers && a2enmod rewrite && mkdir /opt/graphite/run
+RUN /opt/graphite/bin/mod_wsgi-express install-module > /etc/apache2/mods-available/wsgi.load && \
+    a2dissite 000-default && a2ensite graphite && a2enmod wsgi && a2enmod headers && a2enmod rewrite && mkdir /opt/graphite/run && \
+    mkdir -p /var/run/apache2
 
 EXPOSE 80
 


### PR DESCRIPTION
`libapache2-mod-wsgi-py3` is compiled for Python 3.8, but we are using our Python 3.9 in our virtualenv. This was seen as import errors,  nothing worked. The new pip-installed `mod_wsgi` uses our virtualenv-ed Python 3.9, and we tell Apache to use that through `/opt/graphite/bin/mod_wsgi-express install-module > /etc/apache2/mods-available/wsgi.load`.

I've tested the build locally and threw a couple of queries at it. It worked.